### PR TITLE
Upgrade to dinodns 0.0.8 with new storage definitions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,26 @@
+# Checks to make sure the code can build correctly
+name: Build Check
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch: {}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Build Script
+        run: npm run build

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,25 @@
+name: Unit Test Check
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch: {}
+jobs:
+  jest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Jest
+        run: npm run test

--- a/examples/basic-usage/index.ts
+++ b/examples/basic-usage/index.ts
@@ -1,4 +1,4 @@
-import { DefaultServer } from 'dinodns/dist/common/server';
+import { DefaultServer } from 'dinodns/common/server';
 import { DNSOverTCP } from 'dinodns';
 import { RedisStore } from '../../src';
 
@@ -8,12 +8,8 @@ const store = new RedisStore({
   db: 0,
 });
 
-store.set('*.example.com', 'A', {
-  name: '*', // this does not really matter since the name will be replaced by the matching query
-  type: 'A',
-  ttl: 300,
-  data: '127.0.0.1',
-});
+store.set('*.example.com', 'A', '127.0.0.2');
+store.set('example.com', 'A', '127.0.0.1');
 
 const server = new DefaultServer({
   networks: [new DNSOverTCP('localhost', 1054)],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.17.10",
-        "dinodns": "^0.0.6",
+        "dinodns": "^0.0.8",
         "dns-packet": "^5.6.1",
         "ioredis": "^5.4.1",
         "lodash": "^4.17.21",
@@ -62,18 +62,18 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.7.tgz",
-      "integrity": "sha512-9ickoLz+hcXCeh7jrcin+/SLWm+GkxE2kTvoYyp38p4WkdFXfQJxDFGWp/YHjiKLPx06z2A7W8XKuqbReXDzsw==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.8.tgz",
+      "integrity": "sha512-ZsysZyXY4Tlx+Q53XdnOFmqwfB9QDTHYxaZYajWRoBLuLEAwI2UIbtxOjWh/cFaa9IKUlcB+DDuoskLuKu56JA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
-      "integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.8.tgz",
+      "integrity": "sha512-Oixnb+DzmRT30qu9d3tJSQkxuygWm32DFykT4bRoORPa9hZ/L4KhVB/XiRm6KG+roIEM7DBQlmg27kw2HZkdZg==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -82,10 +82,10 @@
         "@babel/helper-compilation-targets": "^7.25.7",
         "@babel/helper-module-transforms": "^7.25.7",
         "@babel/helpers": "^7.25.7",
-        "@babel/parser": "^7.25.7",
+        "@babel/parser": "^7.25.8",
         "@babel/template": "^7.25.7",
         "@babel/traverse": "^7.25.7",
-        "@babel/types": "^7.25.7",
+        "@babel/types": "^7.25.8",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -329,12 +329,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.7.tgz",
-      "integrity": "sha512-aZn7ETtQsjjGG5HruveUK06cU3Hljuhd9Iojm4M8WWv3wLE6OkE5PWbDUkItmMgegmccaITudyuW5RPYrYlgWw==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.8.tgz",
+      "integrity": "sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.25.7"
+        "@babel/types": "^7.25.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -607,9 +607,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.7.tgz",
-      "integrity": "sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.8.tgz",
+      "integrity": "sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.7",
@@ -1745,9 +1745,9 @@
       "integrity": "sha512-YpS0zzoduEhuOWjAotS6A5AVCva7X4lVlYLF0FYHAY9sdraBfnatttHItlWeZdGhuEkf+OzMNg2ZYAx8t+52uQ=="
     },
     "node_modules/@types/node": {
-      "version": "22.7.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
-      "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -2318,9 +2318,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001667",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001667.tgz",
-      "integrity": "sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==",
+      "version": "1.0.30001668",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001668.tgz",
+      "integrity": "sha512-nWLrdxqCdblixUO+27JtGJJE/txpJlyUy5YN1u53wLZkP0emYCo5zgS6QYft7VUYR42LGgi/S5hdLZTrnyIddw==",
       "dev": true,
       "funding": [
         {
@@ -2588,11 +2588,12 @@
       }
     },
     "node_modules/dinodns": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/dinodns/-/dinodns-0.0.6.tgz",
-      "integrity": "sha512-S1aSJ7xAT/vNgS6X2RhtFv016SB/0xSOHgELRR3iPshFOwQw1y3iB3CemvjyiAfK87K4FUNk9FmzOqdS+SUkSA==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/dinodns/-/dinodns-0.0.8.tgz",
+      "integrity": "sha512-u3S5A9jcDZN6tPebT4JNSzuplu/5w8LoiC3lDovDWo9spNE/Bnbc4E1p9OsLHoVTyWXZUp/erqC/I3zZQcv23g==",
       "dependencies": {
-        "dns-packet": "^5.6.1"
+        "dns-packet": "^5.6.1",
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/dir-glob": {
@@ -2645,9 +2646,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.32",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.32.tgz",
-      "integrity": "sha512-M+7ph0VGBQqqpTT2YrabjNKSQ2fEl9PVx6AK3N558gDH9NO8O6XN9SXXFWRo9u9PbEg/bWq+tjXQr+eXmxubCw==",
+      "version": "1.5.37",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.37.tgz",
+      "integrity": "sha512-u7000ZB/X0K78TaQqXZ5ktoR7J79B9US7IkE4zyvcILYwOGY2Tx9GRPYstn7HmuPcMxZ+BDGqIsyLpZQi9ufPw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -5319,9 +5320,9 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.1.tgz",
-      "integrity": "sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
+      "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
       "dev": true,
       "dependencies": {
         "@pkgr/core": "^0.1.0",
@@ -5559,13 +5560,13 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.8.0.tgz",
-      "integrity": "sha512-BjIT/VwJ8+0rVO01ZQ2ZVnjE1svFBiRczcpr1t1Yxt7sT25VSbPfrJtDsQ8uQTy2pilX5nI9gwxhUyLULNentw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.9.0.tgz",
+      "integrity": "sha512-AuD/FXGYRQyqyOBCpNLldMlsCGvmDNxptQ3Dp58/NXeB+FqyvTfXmMyba3PYa0Vi9ybnj7G8S/yd/4Cw8y47eA==",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.8.0",
-        "@typescript-eslint/parser": "8.8.0",
-        "@typescript-eslint/utils": "8.8.0"
+        "@typescript-eslint/eslint-plugin": "8.9.0",
+        "@typescript-eslint/parser": "8.9.0",
+        "@typescript-eslint/utils": "8.9.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5581,15 +5582,15 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.8.0.tgz",
-      "integrity": "sha512-wORFWjU30B2WJ/aXBfOm1LX9v9nyt9D3jsSOxC3cCaTQGCW5k4jNpmjFv3U7p/7s4yvdjHzwtv2Sd2dOyhjS0A==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.9.0.tgz",
+      "integrity": "sha512-Y1n621OCy4m7/vTXNlCbMVp87zSd7NH0L9cXD8aIpOaNlzeWxIK4+Q19A68gSmTNRZn92UjocVUWDthGxtqHFg==",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.8.0",
-        "@typescript-eslint/type-utils": "8.8.0",
-        "@typescript-eslint/utils": "8.8.0",
-        "@typescript-eslint/visitor-keys": "8.8.0",
+        "@typescript-eslint/scope-manager": "8.9.0",
+        "@typescript-eslint/type-utils": "8.9.0",
+        "@typescript-eslint/utils": "8.9.0",
+        "@typescript-eslint/visitor-keys": "8.9.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -5613,14 +5614,14 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.8.0.tgz",
-      "integrity": "sha512-uEFUsgR+tl8GmzmLjRqz+VrDv4eoaMqMXW7ruXfgThaAShO9JTciKpEsB+TvnfFfbg5IpujgMXVV36gOJRLtZg==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.9.0.tgz",
+      "integrity": "sha512-U+BLn2rqTTHnc4FL3FJjxaXptTxmf9sNftJK62XLz4+GxG3hLHm/SUNaaXP5Y4uTiuYoL5YLy4JBCJe3+t8awQ==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.8.0",
-        "@typescript-eslint/types": "8.8.0",
-        "@typescript-eslint/typescript-estree": "8.8.0",
-        "@typescript-eslint/visitor-keys": "8.8.0",
+        "@typescript-eslint/scope-manager": "8.9.0",
+        "@typescript-eslint/types": "8.9.0",
+        "@typescript-eslint/typescript-estree": "8.9.0",
+        "@typescript-eslint/visitor-keys": "8.9.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -5640,12 +5641,12 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.8.0.tgz",
-      "integrity": "sha512-EL8eaGC6gx3jDd8GwEFEV091210U97J0jeEHrAYvIYosmEGet4wJ+g0SYmLu+oRiAwbSA5AVrt6DxLHfdd+bUg==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.9.0.tgz",
+      "integrity": "sha512-bZu9bUud9ym1cabmOYH9S6TnbWRzpklVmwqICeOulTCZ9ue2/pczWzQvt/cGj2r2o1RdKoZbuEMalJJSYw3pHQ==",
       "dependencies": {
-        "@typescript-eslint/types": "8.8.0",
-        "@typescript-eslint/visitor-keys": "8.8.0"
+        "@typescript-eslint/types": "8.9.0",
+        "@typescript-eslint/visitor-keys": "8.9.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5656,12 +5657,12 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/type-utils": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.8.0.tgz",
-      "integrity": "sha512-IKwJSS7bCqyCeG4NVGxnOP6lLT9Okc3Zj8hLO96bpMkJab+10HIfJbMouLrlpyOr3yrQ1cA413YPFiGd1mW9/Q==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.9.0.tgz",
+      "integrity": "sha512-JD+/pCqlKqAk5961vxCluK+clkppHY07IbV3vett97KOV+8C6l+CPEPwpUuiMwgbOz/qrN3Ke4zzjqbT+ls+1Q==",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.8.0",
-        "@typescript-eslint/utils": "8.8.0",
+        "@typescript-eslint/typescript-estree": "8.9.0",
+        "@typescript-eslint/utils": "8.9.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -5679,9 +5680,9 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.8.0.tgz",
-      "integrity": "sha512-QJwc50hRCgBd/k12sTykOJbESe1RrzmX6COk8Y525C9l7oweZ+1lw9JiU56im7Amm8swlz00DRIlxMYLizr2Vw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.9.0.tgz",
+      "integrity": "sha512-SjgkvdYyt1FAPhU9c6FiYCXrldwYYlIQLkuc+LfAhCna6ggp96ACncdtlbn8FmnG72tUkXclrDExOpEYf1nfJQ==",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5691,12 +5692,12 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.8.0.tgz",
-      "integrity": "sha512-ZaMJwc/0ckLz5DaAZ+pNLmHv8AMVGtfWxZe/x2JVEkD5LnmhWiQMMcYT7IY7gkdJuzJ9P14fRy28lUrlDSWYdw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.9.0.tgz",
+      "integrity": "sha512-9iJYTgKLDG6+iqegehc5+EqE6sqaee7kb8vWpmHZ86EqwDjmlqNNHeqDVqb9duh+BY6WCNHfIGvuVU3Tf9Db0g==",
       "dependencies": {
-        "@typescript-eslint/types": "8.8.0",
-        "@typescript-eslint/visitor-keys": "8.8.0",
+        "@typescript-eslint/types": "8.9.0",
+        "@typescript-eslint/visitor-keys": "8.9.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -5718,14 +5719,14 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.8.0.tgz",
-      "integrity": "sha512-QE2MgfOTem00qrlPgyByaCHay9yb1+9BjnMFnSFkUKQfu7adBXDTnCAivURnuPPAG/qiB+kzKkZKmKfaMT0zVg==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.9.0.tgz",
+      "integrity": "sha512-PKgMmaSo/Yg/F7kIZvrgrWa1+Vwn036CdNUvYFEkYbPwOH4i8xvkaRlu148W3vtheWK9ckKRIz7PBP5oUlkrvQ==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.8.0",
-        "@typescript-eslint/types": "8.8.0",
-        "@typescript-eslint/typescript-estree": "8.8.0"
+        "@typescript-eslint/scope-manager": "8.9.0",
+        "@typescript-eslint/types": "8.9.0",
+        "@typescript-eslint/typescript-estree": "8.9.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5739,11 +5740,11 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.8.0.tgz",
-      "integrity": "sha512-8mq51Lx6Hpmd7HnA2fcHQo3YgfX1qbccxQOgZcb4tvasu//zXRaA1j5ZRFeCw/VRAdFi4mRM9DnZw0Nu0Q2d1g==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.9.0.tgz",
+      "integrity": "sha512-Ht4y38ubk4L5/U8xKUBfKNYGmvKvA1CANoxiTRMM+tOLk3lbF3DvzZCxJCRSE+2GdCMSh6zq9VZJc3asc1XuAA==",
       "dependencies": {
-        "@typescript-eslint/types": "8.8.0",
+        "@typescript-eslint/types": "8.9.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@types/lodash": "^4.17.10",
-    "dinodns": "^0.0.6",
+    "dinodns": "^0.0.8",
     "dns-packet": "^5.6.1",
     "ioredis": "^5.4.1",
     "lodash": "^4.17.21",

--- a/src/RedisStore.spec.ts
+++ b/src/RedisStore.spec.ts
@@ -264,6 +264,11 @@ describe('RedisStore', () => {
       client.hdel = jest.fn(async (key: string) => {
         delete internalData[key];
       });
+
+      // @ts-ignore
+      client.del = jest.fn(async (key: string) => {
+        delete internalData[key];
+      });
     });
 
     it('should be able to delete all data from the correct key', async () => {

--- a/src/RedisStore.spec.ts
+++ b/src/RedisStore.spec.ts
@@ -2,6 +2,7 @@ import { RedisStore } from '.';
 import Redis from 'ioredis';
 import { RecordType } from 'dns-packet';
 import { SupportedAnswer } from 'dinodns';
+import { ZoneData } from 'dinodns/types/dns';
 import _ from 'lodash';
 
 jest.mock('ioredis');
@@ -9,15 +10,16 @@ jest.mock('ioredis');
 describe('RedisStore', () => {
   let store: RedisStore;
   let client: Redis;
-  const ARecords: SupportedAnswer[] = [
-    { name: 'example.com', type: 'A', data: '127.0.0.1' },
-    { name: 'example.com', type: 'A', data: '127.0.0.2' },
+  const ARecords: ZoneData['A'][] = [
+    '127.0.0.1',
+    '127.0.0.2'
   ];
 
-  const AAAARecords: SupportedAnswer[] = [
-    { name: 'example.com', type: 'AAAA', data: '::1' },
-    { name: 'example.com', type: 'AAAA', data: '::2' },
+  const AAAARecords: ZoneData['AAAA'][] = [
+    '::1',
+    '::2'
   ];
+
   const internalData = {
     A: JSON.stringify(ARecords),
     AAAA: JSON.stringify(AAAARecords),
@@ -25,13 +27,13 @@ describe('RedisStore', () => {
 
   beforeEach(() => {
     client = new Redis();
-    store = new RedisStore(client);
+    store = new RedisStore({client});
   });
 
   describe('create', () => {
     it('should be able to create a redis store with a passed in client', () => {
       const client = new Redis();
-      const store = new RedisStore(client);
+      const store = new RedisStore({client});
       expect(store).toBeInstanceOf(RedisStore);
     });
 
@@ -156,10 +158,10 @@ describe('RedisStore', () => {
       expect(result2).toEqual([...ARecords, ...AAAARecords]);
 
       const result3 = await store.get('test.com', 'AAAA');
-      expect(result3).toEqual(AAAARecords.map((d) => ({ ...d, name: 'test.com' })));
+      expect(result3).toEqual(AAAARecords);
 
       const result4 = await store.get('test.com');
-      expect(result4).toEqual([...ARecords, ...AAAARecords].map((d) => ({ ...d, name: 'test.com' })));
+      expect(result4).toEqual([...ARecords, ...AAAARecords]);
 
       const result5 = await store.get('notinthere.net');
       expect(result5).toEqual(null);

--- a/src/RedisStore.spec.ts
+++ b/src/RedisStore.spec.ts
@@ -10,15 +10,9 @@ jest.mock('ioredis');
 describe('RedisStore', () => {
   let store: RedisStore;
   let client: Redis;
-  const ARecords: ZoneData['A'][] = [
-    '127.0.0.1',
-    '127.0.0.2'
-  ];
+  const ARecords: ZoneData['A'][] = ['127.0.0.1', '127.0.0.2'];
 
-  const AAAARecords: ZoneData['AAAA'][] = [
-    '::1',
-    '::2'
-  ];
+  const AAAARecords: ZoneData['AAAA'][] = ['::1', '::2'];
 
   const internalData = {
     A: JSON.stringify(ARecords),
@@ -27,13 +21,13 @@ describe('RedisStore', () => {
 
   beforeEach(() => {
     client = new Redis();
-    store = new RedisStore({client});
+    store = new RedisStore({ client });
   });
 
   describe('create', () => {
     it('should be able to create a redis store with a passed in client', () => {
       const client = new Redis();
-      const store = new RedisStore({client});
+      const store = new RedisStore({ client });
       expect(store).toBeInstanceOf(RedisStore);
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,17 @@
 import type { Store, SupportedAnswer, Handler } from 'dinodns';
-import {SupportedRecordType, ZoneData} from "dinodns/types/dns";
+import { SupportedRecordType, ZoneData } from 'dinodns/types/dns';
 import Redis from 'ioredis';
 import type { RedisOptions } from 'ioredis';
 import { Answer, RecordType } from 'dns-packet';
 import { isEqual as _isEqual } from 'lodash';
-import {EventEmitter} from 'events';
+import { EventEmitter } from 'events';
 
 export type RedisStoreOptions = {
-
   /** An optional redis client */
   client?: Redis;
-  
+
   /** Whether the store should emit cache requests. Defaults to true. */
   shouldCache?: boolean;
-
 } & RedisOptions;
 
 export class RedisStore extends EventEmitter implements Store {
@@ -27,7 +25,7 @@ export class RedisStore extends EventEmitter implements Store {
       throw new Error('RedisStore requires options');
     }
 
-    if(options.shouldCache) {
+    if (options.shouldCache) {
       this.shouldCache = options.shouldCache;
     }
 
@@ -40,7 +38,11 @@ export class RedisStore extends EventEmitter implements Store {
     this.client = new Redis(options);
   }
 
-  async get<T extends SupportedRecordType>(name: string, rType?: T, wildcards = true): Promise<ZoneData[T][] | ZoneData[keyof ZoneData][] | null> {
+  async get<T extends SupportedRecordType>(
+    name: string,
+    rType?: T,
+    wildcards = true,
+  ): Promise<ZoneData[T][] | ZoneData[keyof ZoneData][] | null> {
     let key = this.nameToKey(name);
     // first attempt to get the data from the exact match
     if (rType) {
@@ -97,7 +99,7 @@ export class RedisStore extends EventEmitter implements Store {
    */
   async set<T extends SupportedRecordType>(name: string, rType: T, data: ZoneData[T] | ZoneData[T][]): Promise<void> {
     const key = this.nameToKey(name);
-    if(!Array.isArray(data)) {
+    if (!Array.isArray(data)) {
       data = [data];
     }
 
@@ -176,8 +178,8 @@ export class RedisStore extends EventEmitter implements Store {
       console.log('RedisStore: Found data for', name, type, answers);
 
       res.answer(answers);
-      
-      if(this.shouldCache) {
+
+      if (this.shouldCache) {
         this.emitCacheRequest(name, type, result);
       }
     }


### PR DESCRIPTION
Fairly major PR that brings the Redis storage module up to date with the latest definitions for storage created in DinoDNS@0.0.8. Specifically, replaces `Answer` with `ZoneData[T]` definitions. This allows for a more compact, more intuitive declaration within the storage module. See the original [DinoDNS PR for more details](https://github.com/jafayer/DinoDNS/pull/13).

This pull request includes several changes to the `RedisStore` class and its usage, as well as updates to the CI workflows. The most important changes include the refactoring of the `RedisStore` class to use a more flexible options object, improvements to the handling of DNS records, and the addition of build and test workflows.

### Refactoring and Enhancements:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R2-R45): Refactored `RedisStore` to accept an options object, added support for emitting cache requests, and improved type handling for DNS records. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R2-R45) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L55-R85) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L78-R106) [[4]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L95-R115) [[5]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L109-R136) [[6]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L135-R155) [[7]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R166-R196)

### Testing Improvements:

* [`src/RedisStore.spec.ts`](diffhunk://#diff-fe41d60ad2ceb1623659a80eebc1098ebfbcda5eba69e039d305765a31bfaa8cR5-R30): Updated tests to reflect changes in `RedisStore` constructor and DNS record handling. [[1]](diffhunk://#diff-fe41d60ad2ceb1623659a80eebc1098ebfbcda5eba69e039d305765a31bfaa8cR5-R30) [[2]](diffhunk://#diff-fe41d60ad2ceb1623659a80eebc1098ebfbcda5eba69e039d305765a31bfaa8cL159-R158) [[3]](diffhunk://#diff-fe41d60ad2ceb1623659a80eebc1098ebfbcda5eba69e039d305765a31bfaa8cR267-R271)

### Dependency Updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L49-R49): Updated `dinodns` dependency to version `^0.0.8`.

### Example Usage Adjustments:

* [`examples/basic-usage/index.ts`](diffhunk://#diff-e6a41085ad1a59a67fae4ba3b05e44e432d2629fa6890de0e77ee35d6dc16885L1-R1): Corrected import path for `DefaultServer` and simplified DNS record setting. [[1]](diffhunk://#diff-e6a41085ad1a59a67fae4ba3b05e44e432d2629fa6890de0e77ee35d6dc16885L1-R1) [[2]](diffhunk://#diff-e6a41085ad1a59a67fae4ba3b05e44e432d2629fa6890de0e77ee35d6dc16885L11-R12)

### CI Workflow Additions:

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R1-R26): Added a build check workflow to ensure the code can build correctly.
* [`.github/workflows/tests.yaml`](diffhunk://#diff-95557d53bf91069e59d82b9d8fcfaf52ec84a762858983edd5ef3c9b3e4c8191R1-R25): Added a unit test check workflow to run Jest tests.