### PR TITLE
Other/bugfixes and config

### DIFF
--- a/examples/basic-usage/index.ts
+++ b/examples/basic-usage/index.ts
@@ -9,9 +9,10 @@ const store = new RedisStore({
 
 store.set('*.example.com', 'A', '127.0.0.2');
 store.set('example.com', 'A', '127.0.0.1');
+store.set('*', 'A', '127.0.0.1');
 
 const server = new DefaultServer({
-  networks: [new DNSOverTCP('localhost', 1054)],
+  networks: [new DNSOverTCP({ address: 'localhost', port: 1054 })],
 });
 
 server.use(store.handler);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2407,9 +2407,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,27 @@ export class RedisStore extends EventEmitter implements Store {
       }
     }
 
+    // last check for the root wildcard
+    if (wildcards) {
+      const wildcardKey = '*';
+      if (rType) {
+        const data = await this.client.hget(wildcardKey, rType);
+        if (data) {
+          return JSON.parse(data);
+        }
+      } else {
+        const data = await this.client.hgetall(wildcardKey);
+        if (data && Object.keys(data).length > 0) {
+          return Object.values(data)
+            .map((d) => JSON.parse(d))
+            .flat();
+        }
+      }
+    }
+
+    return null;
+  }
+
     return null;
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020", // Or higher, depending on the features you need
-    "module": "ESNext", // Allows ECMAScript Modules (ESM)
+    "module": "CommonJS", // Allows ECMAScript Modules (ESM)
     "esModuleInterop": true, // Allows importing CommonJS modules from ESM
     "allowSyntheticDefaultImports": true, // Allows default imports from modules with no default export
     "strict": true, // Optional: Enables strict type checking


### PR DESCRIPTION
This pull request introduces enhancements to the `RedisStore` class and its associated tests, focusing on the handling of wildcard domain names. The most important changes include adding support for root wildcard records, improving the `resolve` method, and updating the test suite to cover these new functionalities.

Enhancements to `RedisStore`:

* Added support for setting and retrieving root wildcard records in the `RedisStore` class (`src/index.ts`).
* Implemented the `resolve` method to resolve domain names to their corresponding keys, including wildcard handling (`src/index.ts`).

Updates to the test suite:

* Added a test case to verify data retrieval from a plain wildcard (`src/RedisStore.spec.ts`).
* Added a test case for the `resolve` method to ensure it correctly resolves domain names to keys (`src/RedisStore.spec.ts`).
* Added a test case to check the conversion of a top-level wildcard name to the correct representation (`src/RedisStore.spec.ts`).

Changes in example usage:

* Updated the example usage to include setting a root wildcard record (`examples/basic-usage/index.ts`).

Configuration changes:

* Migrate typescript build output to cjs for better compatibility with rest of DinoDNS codebase (`tsconfig.json`)