### PR TITLE
Bump dinodns to v0.0.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.17.10",
-        "dinodns": "^0.0.12",
+        "dinodns": "^0.0.13",
         "dns-packet": "^5.6.1",
         "ioredis": "^5.4.1",
         "lodash": "^4.17.21",
@@ -2490,9 +2490,9 @@
       }
     },
     "node_modules/dinodns": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/dinodns/-/dinodns-0.0.12.tgz",
-      "integrity": "sha512-gFO5S1/3XmAmAC20DyekYn5LTsXVy9D9dLom50GvspkDCMAdyIC3rPF7Q20At6DtshLQkKMfBhBirvRcfcd7Lg==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/dinodns/-/dinodns-0.0.13.tgz",
+      "integrity": "sha512-kA6Q4lUX/GfzIo5Jfdi4/lfw3iKU85KvdE+fRzn6qjPSqvKfnM1TzO0Jy480LpuC0rwFsjRAn70YlHSox6PscQ==",
       "dependencies": {
         "@types/dns-packet": "^5.6.5",
         "dns-packet": "^5.6.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@types/lodash": "^4.17.10",
-    "dinodns": "^0.0.12",
+    "dinodns": "^0.0.13",
     "dns-packet": "^5.6.1",
     "ioredis": "^5.4.1",
     "lodash": "^4.17.21",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change updates the version of the `dinodns` dependency from `0.0.12` to `0.0.13`.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L49-R49): Updated the `dinodns` dependency version from `0.0.12` to `0.0.13`.